### PR TITLE
fix SerialBT.begin

### DIFF
--- a/InubashiriReceiver/InubashiriReceiver.ino
+++ b/InubashiriReceiver/InubashiriReceiver.ino
@@ -72,7 +72,7 @@
 // -------------------------------------------------
 
 void setup() {
-  SerialBT.begin(9600);
+  SerialBT.begin(String(9600));
   delay(500);
 
   // Startup all pins and UART


### PR DESCRIPTION
Arduino IDEで、そのままだと下記のエラーが出たので変更を。

fix SerialBT.begin, 9600 -> String(9600)
```
C:\Working\GitHub\DogTrackerInubashiri\InubashiriReceiver\InubashiriReceiver.ino: In function 'void setup()':
InubashiriReceiver:75:22: error: converting to 'String' from initializer list would use explicit constructor 'String::String(int, unsigned char)'
   SerialBT.begin(9600);
                      ^
In file included from C:\Working\GitHub\DogTrackerInubashiri\InubashiriReceiver\InubashiriReceiver.ino:29:0:
C:\Users\k1331\OneDrive\�h�L�������g\ArduinoData\packages\esp32\hardware\esp32\1.0.4\libraries\BluetoothSerial\src/BluetoothSerial.h:33:14: note:   initializing argument 1 of 'bool BluetoothSerial::begin(String, bool)'
         bool begin(String localName=String(), bool isMaster=false);
              ^
exit status 1
converting to 'String' from initializer list would use explicit constructor 'String::String(int, unsigned char)'
```